### PR TITLE
feat: add VAT (AFM) validation function

### DIFF
--- a/.changeset/green-berries-fetch.md
+++ b/.changeset/green-berries-fetch.md
@@ -1,0 +1,5 @@
+---
+"@tsevdos/el-utils": patch
+---
+
+Add validateAFM

--- a/docs/validationUtils.md
+++ b/docs/validationUtils.md
@@ -5,6 +5,7 @@
 ## Table of Contents
 
 - [**validatePostalCode()**](#validatePostalCode)
+- [**validateAFM()**](#validateAFM)
 
 ---
 
@@ -17,3 +18,14 @@
 **`postalCode`**: The postal code to validate.
 
 **Return Type**: Boolean indicating whether the postal code is valid.
+
+
+### validateAFM()<a id='validateAFM'></a>
+
+**Description**: Validates an a greek tax id / AFM (ΑΦΜ) .
+
+**Parameters:**
+
+**`afm`**: The AFM to validate.
+
+**Return Type**: Boolean indicating whether the AFM is valid.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tsevdos/el-utils",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tsevdos/el-utils",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "license": "MIT",
       "devDependencies": {
         "@changesets/changelog-github": "^0.5.0",

--- a/src/__tests__/validationUtils.test.ts
+++ b/src/__tests__/validationUtils.test.ts
@@ -1,4 +1,4 @@
-import { validatePostalCode } from "../validationUtils";
+import { validatePostalCode, validateAFM } from "../validationUtils";
 
 describe("validatePostalCode", () => {
   it("returns true on existing postal codes", () => {
@@ -18,5 +18,21 @@ describe("validatePostalCode", () => {
     expect(validatePostalCode("99999")).toBe(false);
     expect(validatePostalCode("98765")).toBe(false);
     expect(validatePostalCode("56789")).toBe(false);
+  });
+});
+
+describe("validateAFM", () => {
+  it("returns false for invalid afms", () => {
+    expect(validateAFM("12345678")).toBe(false);
+    expect(validateAFM("xxxxxxxx")).toBe(false);
+    expect(validateAFM("141212176")).toBe(false);
+    expect(validateAFM("111111111")).toBe(false);
+  });
+  it("returns false for valid afms", () => {
+    expect(validateAFM("011111111")).toBe(true);
+    expect(validateAFM("150892297")).toBe(true);
+    expect(validateAFM("126668921")).toBe(true);
+    expect(validateAFM("234893562")).toBe(true);
+    expect(validateAFM("126668921")).toBe(true);
   });
 });

--- a/src/__tests__/validationUtils.test.ts
+++ b/src/__tests__/validationUtils.test.ts
@@ -28,11 +28,27 @@ describe("validateAFM", () => {
     expect(validateAFM("141212176")).toBe(false);
     expect(validateAFM("111111111")).toBe(false);
   });
-  it("returns false for valid afms", () => {
+  it("returns true for valid afms", () => {
     expect(validateAFM("011111111")).toBe(true);
     expect(validateAFM("150892297")).toBe(true);
     expect(validateAFM("126668921")).toBe(true);
     expect(validateAFM("234893562")).toBe(true);
     expect(validateAFM("126668921")).toBe(true);
+  });
+
+  it("works with int or string values", () => {
+    expect(validateAFM(111111111)).toBe(false);
+    expect(validateAFM(1111111111111)).toBe(false);
+    expect(validateAFM(1.1)).toBe(false);
+    expect(validateAFM(1.11111111)).toBe(false);
+    expect(validateAFM("xxxxxxxx")).toBe(false);
+    expect(validateAFM("141212176")).toBe(false);
+
+    expect(validateAFM("150892297")).toBe(true);
+    expect(validateAFM(150892297)).toBe(true);
+    expect(validateAFM(126668921)).toBe(true);
+    expect(validateAFM("126668921")).toBe(true);
+    expect(validateAFM(234893562)).toBe(true);
+    expect(validateAFM("234893562")).toBe(true);
   });
 });

--- a/src/validationUtils.ts
+++ b/src/validationUtils.ts
@@ -2,6 +2,21 @@ import postalCodes from "../data/postal-codes.json";
 
 export function validatePostalCode(postalCode: string): boolean {
   const validPostalCodes = postalCodes.flatMap(({ postalCodes }) => [...postalCodes]);
-
   return validPostalCodes.includes(postalCode);
+}
+
+export function validateAFM(afm: string | string): boolean {
+  const strAfm = afm.toString();
+  if (!strAfm.match(/^\d{9}$/) || strAfm == "000000000") {
+    return false;
+  }
+
+  const last = parseInt(strAfm.charAt(8));
+  let sum = 0,
+    power = 1;
+  for (let i = 7; i >= 0; i--) {
+    power *= 2;
+    sum += parseInt(strAfm.charAt(i)) * power;
+  }
+  return sum % 11 === last;
 }

--- a/src/validationUtils.ts
+++ b/src/validationUtils.ts
@@ -5,7 +5,7 @@ export function validatePostalCode(postalCode: string): boolean {
   return validPostalCodes.includes(postalCode);
 }
 
-export function validateAFM(afm: string | string): boolean {
+export function validateAFM(afm: string | number): boolean {
   const strAfm = afm.toString();
   if (!strAfm.match(/^\d{9}$/) || strAfm == "000000000") {
     return false;


### PR DESCRIPTION
Closes #41 .

Validates a Greek tax identifier also known as AFM (AΦΜ). 
The algorithm to do so is based on a formula but fails with tax identifiers issued prior to 1999 or with specific legal entities that have predefined and "static" identifiers.

Refs:
https://en.wikipedia.org/wiki/VAT_identification_number
https://www.codeproject.com/Articles/96944/VIES-VAT-number-checker
https://stackoverflow.com/questions/4375511/greek-vat-validation-number-code
