### PR TITLE
feat: add formatUtils and formatNumber

### DIFF
--- a/src/formatUtils.test.ts
+++ b/src/formatUtils.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { formatNumber } from "./formatUtils";
+
+describe("formatNumber", () => {
+  it("formats a simple number with the default Greek locale", () => {
+    expect(formatNumber(1234567.89)).toBe("1.234.567,89");
+  });
+
+  it("formats a currency value", () => {
+    const result = formatNumber(1234.56, { style: "currency", currency: "EUR" }).replaceAll("\u00A0", " ");
+    expect(result).toBe("1.234,56 €");
+  });
+
+  it("formats a percentage", () => {
+    expect(formatNumber(0.1234, { style: "percent", minimumFractionDigits: 2 })).toBe("12,34%");
+  });
+
+  it("formats with a custom locale", () => {
+    expect(formatNumber(1234567.89, { locale: "en-US" })).toBe("1,234,567.89");
+  });
+
+  it("supports bigint", () => {
+    expect(formatNumber(1234567890123456789n)).toBe("1.234.567.890.123.456.789");
+  });
+});

--- a/src/formatUtils.ts
+++ b/src/formatUtils.ts
@@ -1,0 +1,14 @@
+export type FormatNumberOptions = Intl.NumberFormatOptions & { locale?: string | string[] };
+
+/**
+ * Formats a number based on the provided options, defaulting to the Greek locale.
+ *
+ * @param {number | bigint} value - The number to format.
+ * @param {FormatNumberOptions} [options={}] - Options for formatting the number.
+ * @returns {string} - The formatted number string.
+ */
+export const formatNumber = (value: number | bigint, options: FormatNumberOptions = {}): string => {
+  const { locale = "el-GR", ...intlOptions } = options;
+
+  return new Intl.NumberFormat(locale, intlOptions).format(value);
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export { isValidLandlinePhone } from "./isValidLandlinePhone";
 export { isValidPhone } from "./isValidPhone";
 // Format utilities
 export { formatWeight } from "./formatWeight";
+export { formatNumber } from "./formatUtils";
 // Language utilities
 export {
   normalizeAndUppercaseGreekString,


### PR DESCRIPTION
Resolves #42.

This PR introduces the `formatUtils` module, featuring the `formatNumber` function to natively format numbers via `Intl.NumberFormat`, defaulting to the Greek (`el-GR`) locale.